### PR TITLE
Fixed corrupted character

### DIFF
--- a/src/me/meiamsome/signeditor/SignEditor.java
+++ b/src/me/meiamsome/signeditor/SignEditor.java
@@ -434,10 +434,10 @@ public class SignEditor extends JavaPlugin implements Listener {
 	}
 	
 	public String colourize(String in) {
-		return (" "+in).replaceAll("([^\\\\](\\\\\\\\)*)&(.)", "$1�$3").replaceAll("([^\\\\](\\\\\\\\)*)&(.)", "$1�$3").replaceAll("(([^\\\\])\\\\((\\\\\\\\)*))&(.)", "$2$3&$5").replaceAll("\\\\\\\\", "\\\\").trim();
+		return (" "+in).replaceAll("([^\\\\](\\\\\\\\)*)&(.)", "$1\u00A7$3").replaceAll("([^\\\\](\\\\\\\\)*)&(.)", "$1\u00A7$3").replaceAll("(([^\\\\])\\\\((\\\\\\\\)*))&(.)", "$2$3&$5").replaceAll("\\\\\\\\", "\\\\").trim();
 	}
 	
 	public String decolourize(String in) {
-		return (" "+in).replaceAll("\\\\","\\\\\\\\").replaceAll("&", "\\\\&").replaceAll("�","&").trim();
+		return (" "+in).replaceAll("\\\\","\\\\\\\\").replaceAll("&", "\\\\&").replaceAll("\u00A7","&").trim();
 	}
 }


### PR DESCRIPTION
Before the fix, trying to make signs with colored text resulted in a question-mark-block symbol followed by the color number rather than a color change.
